### PR TITLE
feat(aws): adds iam service linked role module

### DIFF
--- a/aws/iam-service-linked-role/.terraform.lock.hcl
+++ b/aws/iam-service-linked-role/.terraform.lock.hcl
@@ -1,0 +1,18 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.67.0"
+  constraints = ">= 4.30.0, < 5.0.0"
+  hashes = [
+    "h1:5Zfo3GfRSWBaXs4TGQNOflr1XaYj6pRnVJLX5VAjFX4=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.9.2"
+  constraints = "~> 0.9.1"
+  hashes = [
+    "h1:M93amXwO9KelOaPiyXGak1aiIyf6pYo+FDr6pigIb6M=",
+  ]
+}

--- a/aws/iam-service-linked-role/.tflint.hcl
+++ b/aws/iam-service-linked-role/.tflint.hcl
@@ -1,0 +1,10 @@
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}
+
+plugin "aws" {
+  enabled = true
+  version = "0.17.1"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}

--- a/aws/iam-service-linked-role/README.md
+++ b/aws/iam-service-linked-role/README.md
@@ -1,0 +1,50 @@
+# IAM service linked role
+
+Create an IAM service linked role and manage its attached policies
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.30.0, < 5.0.0 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.9.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.30.0, < 5.0.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | ~> 0.9.1 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_service_linked_role.role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_service_linked_role) | resource |
+| [time_static.last_update](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/static) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aws_service_name"></a> [aws\_service\_name](#input\_aws\_service\_name) | The AWS service to which this role is attached | `string` | n/a | yes |
+| <a name="input_custom_suffix"></a> [custom\_suffix](#input\_custom\_suffix) | Additional string appended to the role name. Not all AWS services support custom suffixes. | `string` | n/a | yes |
+| <a name="input_customer"></a> [customer](#input\_customer) | Customer applied to this role | `string` | `""` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment applied to this role | `string` | `""` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name applied to this role | `string` | `"myIAMrole"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags applied to this role | `map(any)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | AWS IAM role arn |
+| <a name="output_name"></a> [name](#output\_name) | AWS IAM role name |
+| <a name="output_unique_id"></a> [unique\_id](#output\_unique\_id) | AWS IAM role unique ID |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/aws/iam-service-linked-role/main.tf
+++ b/aws/iam-service-linked-role/main.tf
@@ -1,0 +1,14 @@
+locals {
+  interpolated_tags = merge({
+    "Name"           = var.name,
+    "Customer"       = var.customer,
+    "Environment"    = var.environment,
+    "ManagedBy"      = "Terraform",
+    "LastModifiedAt" = time_static.last_update.rfc3339,
+    },
+    var.tags
+  )
+}
+
+resource "time_static" "last_update" {
+}

--- a/aws/iam-service-linked-role/outputs.tf
+++ b/aws/iam-service-linked-role/outputs.tf
@@ -1,0 +1,14 @@
+output "arn" {
+  value       = aws_iam_service_linked_role.role.arn
+  description = "AWS IAM role arn"
+}
+
+output "name" {
+  value       = aws_iam_service_linked_role.role.name
+  description = "AWS IAM role name"
+}
+
+output "unique_id" {
+  value       = aws_iam_service_linked_role.role.unique_id
+  description = "AWS IAM role unique ID"
+}

--- a/aws/iam-service-linked-role/providers.tf
+++ b/aws/iam-service-linked-role/providers.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws",
+      version = ">= 4.30.0, < 5.0.0"
+    }
+    time = {
+      source  = "hashicorp/time",
+      version = "~> 0.9.1"
+    }
+  }
+  required_version = "~> 1.3"
+}

--- a/aws/iam-service-linked-role/role.tf
+++ b/aws/iam-service-linked-role/role.tf
@@ -1,0 +1,6 @@
+resource "aws_iam_service_linked_role" "role" {
+  tags             = merge(local.interpolated_tags, { Name = var.name })
+  aws_service_name = var.aws_service_name
+  custom_suffix    = var.custom_suffix
+  description      = "AWS service linked role ${var.name}"
+}

--- a/aws/iam-service-linked-role/variables.tf
+++ b/aws/iam-service-linked-role/variables.tf
@@ -1,0 +1,34 @@
+variable "name" {
+  description = "Name applied to this role"
+  type        = string
+  default     = "myIAMrole"
+}
+
+variable "customer" {
+  description = "Customer applied to this role"
+  type        = string
+  default     = ""
+}
+
+variable "environment" {
+  description = "Environment applied to this role"
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "Tags applied to this role"
+  type        = map(any)
+  default     = {}
+}
+
+# below are specific modules variables
+variable "aws_service_name" {
+  type        = string
+  description = "The AWS service to which this role is attached"
+}
+
+variable "custom_suffix" {
+  type        = string
+  description = "Additional string appended to the role name. Not all AWS services support custom suffixes."
+}


### PR DESCRIPTION
Adds a new module to create and manage IAM service-linked roles.
This includes defining resources, variables, outputs, and providers.
It also configures tflint for linting and includes a basic README.
