### PR TITLE
fix(aws): Allows null custom suffix for service role

### DIFF
--- a/aws/iam-service-linked-role/README.md
+++ b/aws/iam-service-linked-role/README.md
@@ -34,7 +34,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_service_name"></a> [aws\_service\_name](#input\_aws\_service\_name) | The AWS service to which this role is attached | `string` | n/a | yes |
-| <a name="input_custom_suffix"></a> [custom\_suffix](#input\_custom\_suffix) | Additional string appended to the role name. Not all AWS services support custom suffixes. | `string` | n/a | yes |
+| <a name="input_custom_suffix"></a> [custom\_suffix](#input\_custom\_suffix) | Additional string appended to the role name. Not all AWS services support custom suffixes. | `string` | `null` | no |
 | <a name="input_customer"></a> [customer](#input\_customer) | Customer applied to this role | `string` | `""` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment applied to this role | `string` | `""` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name applied to this role | `string` | `"myIAMrole"` | no |

--- a/aws/iam-service-linked-role/role.tf
+++ b/aws/iam-service-linked-role/role.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_service_linked_role" "role" {
   tags             = merge(local.interpolated_tags, { Name = var.name })
   aws_service_name = var.aws_service_name
-  custom_suffix    = var.custom_suffix
+  custom_suffix    = var.custom_suffix != null ? var.custom_suffix : null
   description      = "AWS service linked role ${var.name}"
 }

--- a/aws/iam-service-linked-role/variables.tf
+++ b/aws/iam-service-linked-role/variables.tf
@@ -31,4 +31,5 @@ variable "aws_service_name" {
 variable "custom_suffix" {
   type        = string
   description = "Additional string appended to the role name. Not all AWS services support custom suffixes."
+  default     = null
 }


### PR DESCRIPTION
Allows a null value for the `custom_suffix` variable, ensuring that the service-linked role can be created even when a custom suffix is not provided.
This prevents errors when the variable is not explicitly set.
